### PR TITLE
[.travis.yml] we use script/test not rake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ rvm:
 notifications:
   email: false
 bundler_args: --without guard
+script: script/test


### PR DESCRIPTION
Should fix:
```
$ bundle exec rake
rake aborted!
No Rakefile found (looking for: rakefile, Rakefile, rakefile.rb, Rakefile.rb)
/home/travis/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `eval'
/home/travis/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```
As seen in:
https://travis-ci.org/jnunemaker/nunes/jobs/83194188