### PR TITLE
Include cache key used in hit/miss metrics

### DIFF
--- a/lib/nunes/subscribers/active_support.rb
+++ b/lib/nunes/subscribers/active_support.rb
@@ -25,7 +25,7 @@ module Nunes
         hit = payload[:hit]
         unless hit.nil?
           hit_type = hit ? :hit : :miss
-          increment "active_support.cache.#{hit_type}"
+          increment "active_support.cache.#{hit_type}.#{payload[:key]}"
         end
       end
 

--- a/test/cache_instrumentation_test.rb
+++ b/test/cache_instrumentation_test.rb
@@ -30,7 +30,7 @@ class CacheInstrumentationTest < ActiveSupport::TestCase
     cache.read('foo')
 
     assert_timer "active_support.cache.read"
-    assert_counter "active_support.cache.miss"
+    assert_counter "active_support.cache.miss.foo"
   end
 
   test "cache_read hit" do
@@ -39,7 +39,7 @@ class CacheInstrumentationTest < ActiveSupport::TestCase
     cache.read('foo')
 
     assert_timer "active_support.cache.read"
-    assert_counter "active_support.cache.hit"
+    assert_counter "active_support.cache.hit.foo"
   end
 
   test "cache_generate" do


### PR DESCRIPTION
It could be useful to have hit/miss metrics by key, to see which cache keys are being using effectively.

In this current state it's a breaking change as it adds the key right to the end of `active_support.cache.#{hit_type}`

It could also be added as a separate metric. Interested in your thoughts here: if this change is worthwhile, and if it should be a new metric or added to this existing metric.