### PR TITLE
Include active_support/core_ext/class/subclasses

### DIFF
--- a/lib/nunes/adapter.rb
+++ b/lib/nunes/adapter.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/class/subclasses'
+
 module Nunes
   class Adapter
     # Private: Wraps a given object with the correct adapter/decorator.


### PR DESCRIPTION
Used on [line 29](https://github.com/jnunemaker/nunes/blob/38a4d0a9d2e0dbe963805ce8cb5c43127ad81917/lib/nunes/adapter.rb#L29).