### PR TITLE
Allow disabling some metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.1.0
   - 2.2.0
 notifications:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # master
 
 * no longer doing underscore on active job class name when instrumenting it (ie: active_job.spam_detector_job.perform changed to active_job.SpamDetectorJob.perform)
+* drop ruby 1.9 support
 
 # 0.4.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# master
+
+* no longer doing underscore on active job class name when instrumenting it (ie: active_job.spam_detector_job.perform changed to active_job.SpamDetectorJob.perform)
+
 # 0.4.0
 
 ## Backwards Compatibility Break

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Or install it yourself as:
 
 ## Compatibility
 
-* >= Ruby 1.9
+* >= Ruby 2.0
 * Rails 4.2.x
 
 Note: you can use v0.3.1 is for rails 3.2.x support.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Based on those events, you'll get metrics like this in instrumental and statsd:
 * `action_controller.format.html`
 * `action_controller.controller.Admin.PostsController.new.status.403`
 * `action_controller.controller.Admin.PostsController.index.format.json`
-* `action_controller.exception.RuntimeError` - where RuntimeError is the class of any exceptions that occur while processing a controller's action.
 * `active_support.cache.hit`
 * `active_support.cache.miss`
 

--- a/lib/nunes/adapter.rb
+++ b/lib/nunes/adapter.rb
@@ -55,10 +55,10 @@ module Nunes
     ReplaceRegex = /[^a-z0-9\-_]+/i
 
     # Private: The default metric namespace separator.
-    Separator = "."
+    Separator = ".".freeze
 
     # Private
-    Nothing = ""
+    Nothing = "".freeze
 
     # Private: Prepare a metric name before it is sent to the adapter's client.
     def prepare(metric, replacement = Separator)

--- a/lib/nunes/subscriber.rb
+++ b/lib/nunes/subscriber.rb
@@ -3,7 +3,10 @@ require "active_support/notifications"
 module Nunes
   class Subscriber
     # Private: The bang character that is the first char of some events.
-    BANG = '!'
+    BANG = "!".freeze
+
+    # Private: The dot charactor used to determine the method name.
+    DOT = ".".freeze
 
     # Public: Setup a subscription for the subscriber using the
     # provided adapter.
@@ -34,7 +37,7 @@ module Nunes
       # when in production
       return if name.start_with?(BANG)
 
-      method_name = name.split('.').first
+      method_name = name.split(DOT).first
 
       if respond_to?(method_name)
         send(method_name, start, ending, transaction_id, payload)

--- a/lib/nunes/subscribers/action_controller.rb
+++ b/lib/nunes/subscribers/action_controller.rb
@@ -13,37 +13,58 @@ module Nunes
 
       class << self
         attr_accessor :instrument_format
+        attr_accessor :instrument_view_runtime
+        attr_accessor :instrument_db_runtime
       end
 
+      # Public: Should we instrument the number of requests per format overall and per controller/action.
       self.instrument_format = true
 
+      # Public: Should we instrument the view runtime overall and per controller/action.
+      self.instrument_view_runtime = true
+
+      # Public: Should we instrument the db runtime overall and per controller/action.
+      self.instrument_db_runtime = true
+
       def process_action(start, ending, transaction_id, payload)
-        controller = payload[:controller]
-        action = payload[:action]
-        status = payload[:status]
-
-        db_runtime = payload[:db_runtime]
-        db_runtime = db_runtime.round if db_runtime
-
-        view_runtime = payload[:view_runtime]
-        view_runtime = view_runtime.round if view_runtime
-
         runtime = ((ending - start) * 1_000).round
-
         timing "action_controller.runtime.total", runtime
-        timing "action_controller.runtime.view", view_runtime if view_runtime
-        timing "action_controller.runtime.db", db_runtime if db_runtime
 
+        status = payload[:status]
         increment "action_controller.status.#{status}" if status
 
+        controller = payload[:controller]
+        action = payload[:action]
+
         if controller && action
-          namespace = "action_controller.controller.#{controller}.#{action}"
+          timing "action_controller.controller.#{controller}.#{action}.runtime.total", runtime
+          increment "action_controller.controller.#{controller}.#{action}.status.#{status}" if status
+        end
 
-          timing "#{namespace}.runtime.total", runtime
-          timing "#{namespace}.runtime.view", view_runtime if view_runtime
-          timing "#{namespace}.runtime.db", db_runtime if db_runtime
+        if self.class.instrument_view_runtime
+          view_runtime = payload[:view_runtime]
+          view_runtime = view_runtime.round if view_runtime
 
-          increment "#{namespace}.status.#{status}" if status
+          if view_runtime
+            timing "action_controller.runtime.view", view_runtime
+
+            if controller && action
+              timing "action_controller.controller.#{controller}.#{action}.runtime.view", view_runtime
+            end
+          end
+        end
+
+        if self.class.instrument_db_runtime
+          db_runtime = payload[:db_runtime]
+          db_runtime = db_runtime.round if db_runtime
+
+          if db_runtime
+            timing "action_controller.runtime.db", db_runtime
+
+            if controller && action
+              timing "action_controller.controller.#{controller}.#{action}.runtime.db", db_runtime
+            end
+          end
         end
 
         if self.class.instrument_format
@@ -54,7 +75,7 @@ module Nunes
             increment "action_controller.format.#{format}"
 
             if controller && action
-              increment "#{namespace}.format.#{format}"
+              increment "action_controller.controller.#{controller}.#{action}.format.#{format}"
             end
           end
         end

--- a/lib/nunes/subscribers/action_view.rb
+++ b/lib/nunes/subscribers/action_view.rb
@@ -30,14 +30,17 @@ module Nunes
       end
 
       # Private: What to replace file separators with.
-      FileSeparatorReplacement = "_"
+      FileSeparatorReplacement = "_".freeze
+
+      # Private: An empty string.
+      Nothing = "".freeze
 
       # Private: Converts an identifier to a metric name. Strips out the rails
       # root from the full path.
       #
       # identifier - The String full path to the template or partial.
       def identifier_to_metric(kind, identifier)
-        view_path = identifier.to_s.gsub(::Rails.root.to_s, "")
+        view_path = identifier.to_s.gsub(::Rails.root.to_s, Nothing)
         metric = adapter.prepare(view_path, FileSeparatorReplacement)
         "action_view.#{kind}.#{metric}"
       end

--- a/lib/nunes/subscribers/active_job.rb
+++ b/lib/nunes/subscribers/active_job.rb
@@ -13,16 +13,15 @@ module Nunes
 
       def perform(start, ending, transaction_id, payload)
         runtime = ((ending - start) * 1_000).round
-        job = payload[:job].class.to_s.underscore
+        job = payload[:job].class.to_s
 
         timing "active_job.#{job}.perform", runtime
       end
 
       def enqueue(start, ending, transaction_id, payload)
-        job = payload[:job].class.to_s.underscore
+        job = payload[:job].class.to_s
         increment "active_job.#{job}.enqueue"
       end
     end
   end
 end
-

--- a/lib/nunes/subscribers/active_record.rb
+++ b/lib/nunes/subscribers/active_record.rb
@@ -11,11 +11,14 @@ module Nunes
         Pattern
       end
 
+      # Private: Used to detect the operation from the sql.
+      Space = " ".freeze
+
       def sql(start, ending, transaction_id, payload)
         runtime = ((ending - start) * 1_000).round
         name = payload[:name]
         sql = payload[:sql].to_s.strip
-        operation = sql.split(' ', 2).first.to_s.downcase
+        operation = sql.split(Space, 2).first.to_s.downcase
 
         timing "active_record.sql", runtime
 

--- a/test/controller_instrumentation_test.rb
+++ b/test/controller_instrumentation_test.rb
@@ -76,7 +76,6 @@ class ControllerInstrumentationTest < ActionController::TestCase
 
     assert_response :success
 
-    assert_counter "action_controller.exception.RuntimeError"
     assert_counter "action_controller.format.html"
 
     assert_timer "action_controller.runtime.total"
@@ -84,5 +83,18 @@ class ControllerInstrumentationTest < ActionController::TestCase
 
     assert_no_timer "action_controller.runtime.view"
     assert_no_timer "action_controller.controller.PostsController.some_boom.runtime.view"
+  end
+
+  test "with instrument format disabled" do
+    begin
+      original_format_enabled = Nunes::Subscribers::ActionController.instrument_format
+      Nunes::Subscribers::ActionController.instrument_format = false
+
+      get :index
+
+      refute_counter "action_controller.format.html"
+    ensure
+      Nunes::Subscribers::ActionController.instrument_format = original_format_enabled
+    end
   end
 end

--- a/test/controller_instrumentation_test.rb
+++ b/test/controller_instrumentation_test.rb
@@ -23,10 +23,12 @@ class ControllerInstrumentationTest < ActionController::TestCase
     assert_counter "action_controller.format.html"
 
     assert_timer "action_controller.runtime.total"
+    assert_timer "action_controller.runtime.db"
     assert_timer "action_controller.runtime.view"
 
     assert_timer "action_controller.controller.PostsController.index.runtime.total"
     assert_timer "action_controller.controller.PostsController.index.runtime.view"
+    assert_timer "action_controller.controller.PostsController.index.runtime.db"
   end
 
   test "send_data" do
@@ -67,8 +69,8 @@ class ControllerInstrumentationTest < ActionController::TestCase
     assert_timer "action_controller.runtime.total"
     assert_timer "action_controller.controller.PostsController.some_redirect.runtime.total"
 
-    assert_no_timer "action_controller.runtime.view"
-    assert_no_timer "action_controller.controller.PostsController.some_redirect.runtime.view"
+    refute_timer "action_controller.runtime.view"
+    refute_timer "action_controller.controller.PostsController.some_redirect.runtime.view"
   end
 
   test "action with exception" do
@@ -81,8 +83,8 @@ class ControllerInstrumentationTest < ActionController::TestCase
     assert_timer "action_controller.runtime.total"
     assert_timer "action_controller.controller.PostsController.some_boom.runtime.total"
 
-    assert_no_timer "action_controller.runtime.view"
-    assert_no_timer "action_controller.controller.PostsController.some_boom.runtime.view"
+    refute_timer "action_controller.runtime.view"
+    refute_timer "action_controller.controller.PostsController.some_boom.runtime.view"
   end
 
   test "with instrument format disabled" do
@@ -95,6 +97,34 @@ class ControllerInstrumentationTest < ActionController::TestCase
       refute_counter "action_controller.format.html"
     ensure
       Nunes::Subscribers::ActionController.instrument_format = original_format_enabled
+    end
+  end
+
+  test "with instrument db runtime disabled" do
+    begin
+      original_format_enabled = Nunes::Subscribers::ActionController.instrument_db_runtime
+      Nunes::Subscribers::ActionController.instrument_db_runtime = false
+
+      get :index
+
+      refute_timer "action_controller.runtime.db"
+      refute_timer "action_controller.controller.PostsController.index.runtime.db"
+    ensure
+      Nunes::Subscribers::ActionController.instrument_db_runtime = original_format_enabled
+    end
+  end
+
+  test "with instrument view runtime disabled" do
+    begin
+      original_format_enabled = Nunes::Subscribers::ActionController.instrument_view_runtime
+      Nunes::Subscribers::ActionController.instrument_view_runtime = false
+
+      get :index
+
+      refute_timer "action_controller.runtime.view"
+      refute_timer "action_controller.controller.PostsController.index.runtime.view"
+    ensure
+      Nunes::Subscribers::ActionController.instrument_view_runtime = original_format_enabled
     end
   end
 end

--- a/test/instrumentable_test.rb
+++ b/test/instrumentable_test.rb
@@ -59,7 +59,7 @@ class InstrumentationTest < ActiveSupport::TestCase
 
     assert_not_nil event, "No events were found."
     assert_equal "Thing.yo", event.payload[:metric]
-    assert_in_delta 0, event.duration, 0.1
+    assert_in_delta 0, event.duration, 0.2
 
     assert_timer "Thing.yo"
   end

--- a/test/job_instrumentation_test.rb
+++ b/test/job_instrumentation_test.rb
@@ -16,15 +16,15 @@ class JobInstrumentationTest < ActiveSupport::TestCase
     p = Post.new(title: 'Testing')
     SpamDetectorJob.perform_now(p)
 
-    assert_timer   "active_job.spam_detector_job.perform"
+    assert_timer   "active_job.SpamDetectorJob.perform"
   end
 
   test "perform_later" do
     p = Post.create!(title: 'Testing')
     SpamDetectorJob.perform_later(p)
 
-    assert_timer   "active_job.spam_detector_job.perform"
-    assert_counter "active_job.spam_detector_job.enqueue"
+    assert_timer   "active_job.SpamDetectorJob.perform"
+    assert_counter "active_job.SpamDetectorJob.enqueue"
   end
 
 end

--- a/test/namespaced_job_instrumentation_test.rb
+++ b/test/namespaced_job_instrumentation_test.rb
@@ -1,6 +1,6 @@
 require "helper"
 
-class JobInstrumentationTest < ActiveSupport::TestCase
+class NamespacedJobInstrumentationTest < ActiveSupport::TestCase
   setup :setup_subscriber
   teardown :teardown_subscriber
 
@@ -14,16 +14,16 @@ class JobInstrumentationTest < ActiveSupport::TestCase
 
   test "perform_now" do
     post = Post.new(title: 'Testing')
-    SpamDetectorJob.perform_now(post)
+    Spam::DetectorJob.perform_now(post)
 
-    assert_timer   "active_job.SpamDetectorJob.perform"
+    assert_timer   "active_job.Spam.DetectorJob.perform"
   end
 
   test "perform_later" do
     post = Post.create!(title: 'Testing')
-    SpamDetectorJob.perform_later(post)
+    Spam::DetectorJob.perform_later(post)
 
-    assert_timer   "active_job.SpamDetectorJob.perform"
-    assert_counter "active_job.SpamDetectorJob.enqueue"
+    assert_timer   "active_job.Spam.DetectorJob.perform"
+    assert_counter "active_job.Spam.DetectorJob.enqueue"
   end
 end

--- a/test/rails_app/app/controllers/admin/posts_controller.rb
+++ b/test/rails_app/app/controllers/admin/posts_controller.rb
@@ -1,12 +1,7 @@
 class Admin::PostsController < ApplicationController
-  # Use fake post for controller as I don't want active record to mingle here.
-  Post = Struct.new(:title)
-
   def index
-    @posts = [
-      Post.new('First'),
-      Post.new('Second'),
-    ]
+    @posts = Post.all
+
     respond_to do |format|
       format.html { render }
       format.json { render :json => @posts }

--- a/test/rails_app/app/controllers/posts_controller.rb
+++ b/test/rails_app/app/controllers/posts_controller.rb
@@ -1,12 +1,6 @@
 class PostsController < ApplicationController
-  # Use fake post for controller as I don't want active record to mingle here.
-  Post = Struct.new(:title)
-
   def index
-    @posts = [
-      Post.new('First'),
-      Post.new('Second'),
-    ]
+    @posts = Post.all
   end
 
   def some_data

--- a/test/rails_app/app/jobs/spam/detector_job.rb
+++ b/test/rails_app/app/jobs/spam/detector_job.rb
@@ -1,0 +1,11 @@
+module Spam
+  class DetectorJob < ActiveJob::Base
+    queue_as :default
+
+    def perform(*posts)
+      posts.detect do |post|
+        post.title.include?("Buy watches cheap!")
+      end
+    end
+  end
+end

--- a/test/support/adapter_test_helpers.rb
+++ b/test/support/adapter_test_helpers.rb
@@ -2,13 +2,23 @@ module AdapterTestHelpers
   extend ActiveSupport::Concern
 
   included do
-    setup :setup_memory_adapter
+    setup :setup_memory_adapter, :setup_data
+    teardown :clean_data
   end
 
   attr_reader :adapter
 
   def setup_memory_adapter
     @adapter = Nunes::Adapters::Memory.new
+  end
+
+  def setup_data
+    Post.create(:title => "First")
+    Post.create(:title => "Second")
+  end
+
+  def clean_data
+    Post.delete_all
   end
 
   def assert_timer(metric)
@@ -24,6 +34,11 @@ module AdapterTestHelpers
   def assert_counter(metric)
     assert adapter.counter?(metric),
       "Expected the counter #{metric.inspect} to be included in #{adapter.counter_metric_names.inspect}, but it was not."
+  end
+
+  def refute_counter(metric)
+    refute adapter.counter?(metric),
+      "Expected the counter #{metric.inspect} to not be included in #{adapter.counter_metric_names.inspect}, but it was."
   end
 
   def assert_no_counter(metric)

--- a/test/support/adapter_test_helpers.rb
+++ b/test/support/adapter_test_helpers.rb
@@ -26,7 +26,7 @@ module AdapterTestHelpers
       "Expected the timer #{metric.inspect} to be included in #{adapter.timer_metric_names.inspect}, but it was not."
   end
 
-  def assert_no_timer(metric)
+  def refute_timer(metric)
     assert ! adapter.timer?(metric),
       "Expected the timer #{metric.inspect} to not be included in #{adapter.timer_metric_names.inspect}, but it was."
   end


### PR DESCRIPTION
Sets up a pattern for disabling other things in the future and makes it easy to disable ones that cause extra throughput while providing little value.

Also a few tweaks in this:

* freeze constant strings
* stop trying to "fancy" up job names in metrics