### PR TITLE
Keep single metric namespace for ruby namespaces

### DIFF
--- a/lib/nunes.rb
+++ b/lib/nunes.rb
@@ -37,4 +37,16 @@ module Nunes
 
     subscribers
   end
+
+  # Private: What ruby uses to separate namespaces.
+  NAMESPACE_SEPARATOR = "::".freeze
+
+  # Private: What nunes uses to separate namespaces in the metric.
+  METRIC_NAMESPACE_SEPARATOR = "-".freeze
+
+  # Private: Converts a class to a metric safe name.
+  def self.class_to_metric(class_or_class_name)
+    return if class_or_class_name.nil?
+    class_or_class_name.to_s.gsub(NAMESPACE_SEPARATOR, METRIC_NAMESPACE_SEPARATOR)
+  end
 end

--- a/lib/nunes/instrumentable.rb
+++ b/lib/nunes/instrumentable.rb
@@ -24,7 +24,7 @@ module Nunes
         if name.nil?
           raise ArgumentError, "For class methods you must provide the full name of the metric."
         else
-          "#{name}.#{method_name}"
+          "#{::Nunes.class_to_metric(name)}.#{method_name}"
         end
       }
 

--- a/lib/nunes/subscribers/action_controller.rb
+++ b/lib/nunes/subscribers/action_controller.rb
@@ -33,7 +33,7 @@ module Nunes
         status = payload[:status]
         increment "action_controller.status.#{status}" if status
 
-        controller = payload[:controller]
+        controller = ::Nunes.class_to_metric(payload[:controller])
         action = payload[:action]
 
         if controller && action

--- a/lib/nunes/subscribers/action_mailer.rb
+++ b/lib/nunes/subscribers/action_mailer.rb
@@ -13,7 +13,7 @@ module Nunes
 
       def deliver(start, ending, transaction_id, payload)
         runtime = ((ending - start) * 1_000).round
-        mailer = payload[:mailer]
+        mailer = ::Nunes.class_to_metric(payload[:mailer])
 
         if mailer
           timing "action_mailer.deliver.#{mailer}", runtime
@@ -22,7 +22,7 @@ module Nunes
 
       def receive(start, ending, transaction_id, payload)
         runtime = ((ending - start) * 1_000).round
-        mailer = payload[:mailer]
+        mailer = ::Nunes.class_to_metric(payload[:mailer])
 
         if mailer
           timing "action_mailer.receive.#{mailer}", runtime

--- a/lib/nunes/subscribers/active_job.rb
+++ b/lib/nunes/subscribers/active_job.rb
@@ -13,13 +13,13 @@ module Nunes
 
       def perform(start, ending, transaction_id, payload)
         runtime = ((ending - start) * 1_000).round
-        job = payload[:job].class.to_s
+        job = ::Nunes.class_to_metric(payload[:job].class)
 
         timing "active_job.#{job}.perform", runtime
       end
 
       def enqueue(start, ending, transaction_id, payload)
-        job = payload[:job].class.to_s
+        job = ::Nunes.class_to_metric(payload[:job].class)
         increment "active_job.#{job}.enqueue"
       end
     end

--- a/test/namespaced_controller_instrumentation_test.rb
+++ b/test/namespaced_controller_instrumentation_test.rb
@@ -19,21 +19,21 @@ class NamespacedControllerInstrumentationTest < ActionController::TestCase
 
     assert_response :success
 
-    assert_timer "action_controller.controller.Admin.PostsController.index.runtime.total"
-    assert_timer "action_controller.controller.Admin.PostsController.index.runtime.view"
-    assert_timer "action_controller.controller.Admin.PostsController.index.runtime.db"
+    assert_timer "action_controller.controller.Admin-PostsController.index.runtime.total"
+    assert_timer "action_controller.controller.Admin-PostsController.index.runtime.view"
+    assert_timer "action_controller.controller.Admin-PostsController.index.runtime.db"
 
     assert_counter "action_controller.format.html"
     assert_counter "action_controller.status.200"
 
-    assert_counter "action_controller.controller.Admin.PostsController.index.format.html"
-    assert_counter "action_controller.controller.Admin.PostsController.index.status.200"
+    assert_counter "action_controller.controller.Admin-PostsController.index.format.html"
+    assert_counter "action_controller.controller.Admin-PostsController.index.status.200"
   end
 
   test "process_action w/ json" do
     get :index, format: :json
 
-    assert_counter "action_controller.controller.Admin.PostsController.index.format.json"
+    assert_counter "action_controller.controller.Admin-PostsController.index.format.json"
   end
 
   test "process_action bad_request" do
@@ -41,6 +41,6 @@ class NamespacedControllerInstrumentationTest < ActionController::TestCase
 
     assert_response :forbidden
 
-    assert_counter "action_controller.controller.Admin.PostsController.new.status.403"
+    assert_counter "action_controller.controller.Admin-PostsController.new.status.403"
   end
 end

--- a/test/namespaced_job_instrumentation_test.rb
+++ b/test/namespaced_job_instrumentation_test.rb
@@ -16,14 +16,14 @@ class NamespacedJobInstrumentationTest < ActiveSupport::TestCase
     post = Post.new(title: 'Testing')
     Spam::DetectorJob.perform_now(post)
 
-    assert_timer   "active_job.Spam.DetectorJob.perform"
+    assert_timer   "active_job.Spam-DetectorJob.perform"
   end
 
   test "perform_later" do
     post = Post.create!(title: 'Testing')
     Spam::DetectorJob.perform_later(post)
 
-    assert_timer   "active_job.Spam.DetectorJob.perform"
-    assert_counter "active_job.Spam.DetectorJob.enqueue"
+    assert_timer   "active_job.Spam-DetectorJob.perform"
+    assert_counter "active_job.Spam-DetectorJob.enqueue"
   end
 end

--- a/test/namespaced_mailer_instrumentation_test.rb
+++ b/test/namespaced_mailer_instrumentation_test.rb
@@ -1,0 +1,31 @@
+require "helper"
+
+class NamespacedMailerInstrumentationTest < ActionMailer::TestCase
+  tests Admin::PostMailer
+
+  setup :setup_subscriber
+  teardown :teardown_subscriber
+
+  def setup_subscriber
+    @subscriber = Nunes::Subscribers::ActionMailer.subscribe(adapter)
+  end
+
+  def teardown_subscriber
+    ActiveSupport::Notifications.unsubscribe @subscriber if @subscriber
+  end
+
+  test "deliver_now" do
+    Admin::PostMailer.created.deliver_now
+    assert_timer "action_mailer.deliver.Admin-PostMailer"
+  end
+
+  test "deliver_later" do
+    Admin::PostMailer.created.deliver_later
+    assert_timer "action_mailer.deliver.Admin-PostMailer"
+  end
+
+  test "receive" do
+    Admin::PostMailer.receive Admin::PostMailer.created
+    assert_timer "action_mailer.receive.Admin-PostMailer"
+  end
+end

--- a/test/namespaced_model_instrumentation_test.rb
+++ b/test/namespaced_model_instrumentation_test.rb
@@ -1,0 +1,55 @@
+require "helper"
+
+class NamespacedModelInstrumentationTest < ActiveSupport::TestCase
+  setup :setup_subscriber
+  teardown :teardown_subscriber
+
+  def setup_subscriber
+    @subscriber = Nunes::Subscribers::ActiveRecord.subscribe(adapter)
+  end
+
+  def teardown_subscriber
+    ActiveSupport::Notifications.unsubscribe @subscriber if @subscriber
+  end
+
+  test "transaction" do
+    Admin::Post.create(title: 'Testing')
+
+    assert_timer "active_record.sql.transaction_begin"
+    assert_timer "active_record.sql.transaction_commit"
+  end
+
+  test "create" do
+    Admin::Post.create(title: 'Testing')
+
+    assert_timer "active_record.sql"
+    assert_timer "active_record.sql.insert"
+  end
+
+  test "update" do
+    post = Admin::Post.create
+    adapter.clear
+    post.update_attributes(title: "Title")
+
+    assert_timer "active_record.sql"
+    assert_timer "active_record.sql.update"
+  end
+
+  test "find" do
+    post = Admin::Post.create
+    adapter.clear
+    Admin::Post.find(post.id)
+
+    assert_timer "active_record.sql"
+    assert_timer "active_record.sql.select"
+  end
+
+  test "destroy" do
+    post = Admin::Post.create
+    adapter.clear
+    post.destroy
+
+    assert_timer "active_record.sql"
+    assert_timer "active_record.sql.delete"
+  end
+end

--- a/test/nunes_test.rb
+++ b/test/nunes_test.rb
@@ -17,4 +17,12 @@ class NunesTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "class_to_metric" do
+    assert_equal nil, Nunes.class_to_metric(nil)
+    assert_equal "Foo", Nunes.class_to_metric("Foo")
+    assert_equal "Nunes", Nunes.class_to_metric(Nunes)
+    assert_equal "Spam-DetectorJob", Nunes.class_to_metric(Spam::DetectorJob)
+    assert_equal "Spam-DetectorJob", Nunes.class_to_metric("Spam::DetectorJob")
+  end
 end

--- a/test/rails_app/app/mailers/admin/post_mailer.rb
+++ b/test/rails_app/app/mailers/admin/post_mailer.rb
@@ -1,0 +1,13 @@
+module Admin
+  class PostMailer < ActionMailer::Base
+    default from: "from@example.com"
+
+    def created
+      mail to: "to@example.org"
+    end
+
+    def receive(email)
+      # do something
+    end
+  end
+end

--- a/test/rails_app/app/models/admin/post.rb
+++ b/test/rails_app/app/models/admin/post.rb
@@ -1,0 +1,5 @@
+module Admin
+  class Post < ActiveRecord::Base
+    self.table_name = "posts"
+  end
+end

--- a/test/rails_app/app/views/admin/post_mailer/created.text.erb
+++ b/test/rails_app/app/views/admin/post_mailer/created.text.erb
@@ -1,0 +1,1 @@
+PostMailer#created.


### PR DESCRIPTION
Rather than have Admin.UsersController we'll now have Admin-UsersController since "." is a very common metric namespace separator. This allows easier globbing of all controllers, jobs, etc. (ie: action_controller.controller.* matches all controllers, not just top level)  without affecting slicing a particular group (ie: Admin-* for all admin namespace controllers).

closes #24 